### PR TITLE
Better Hostname Resolution and Bandwidth Controls

### DIFF
--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/config.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/config.js
@@ -42,6 +42,16 @@ return L.view.extend({
 		o.default = '/tmp/usage.db';
 		o.rmempty = false;
 
+		o = s.option(form.Flag, 'speed_in_bits', _('Transfer speed in bits'), _("Display the download/upload speed in bit/s instead of Bytes/s"));
+		o.default = 0;
+		o.rmempty = true;
+		
+		o = s.option(form.Value, 'downstream_bandwidth', _("Downstream Bandwidth"), _("The Downstream Bandwidth of the internet connection measured in Kb/s (kilobits/sec) (1 byte = 8 bits)"))
+		o.default = 8192;
+
+		o = s.option(form.Value, 'upstream_bandwidth', _("Upstream Bandwidth"), _("The Upstream Bandwidth of the internet connection measured in Kb/s (kilobits/sec) (1 byte = 8 bits)"))
+		o.default = 8192;
+
 		return m.render();
 	},
 


### PR DESCRIPTION
I have added support to wrtbwmon for getting the DHCP leases from /tmp/dhcp.leases

I have also changed the bandwidth control into a config with seperate upstream/downstream values

I have also added an option to view speeds in bits/second instead of bytes for people who prefer to see it that way

For it to work properly, you need to also use the version of wrtbwmon I have also committed