### PR TITLE
Tiny patch for custom page: textarea:text indent

### DIFF
--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/custom.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/custom.js
@@ -20,7 +20,7 @@ return L.view.extend({
 			E('div', {'class': 'cbi-section'}, [
 				E('textarea', {
 					'id': 'custom_hosts',
-					'style': 'width: 100%',
+					'style': 'width: 100%;padding: .5em;',
 					'rows': 20
 				}, data)
 			])


### PR DESCRIPTION
The text is too close to the border that some characters cannot be seen clearly.