### PR TITLE
Fix `macaddr` undefined exception

### DIFF
--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
@@ -342,7 +342,7 @@ function resolveHostNameByMACAddr() {
 		];
 		for (var i = 0; i < leaseNames.length; i++) {
 			for (var j = 0; j < leaseNames[i].length; j++) {
-				macaddr = leaseNames[i][j].macaddr.toLowerCase();
+				macaddr = leaseNames[i][j].macaddr?.toLowerCase();
 				if (!(macaddr in hostNames) || hostNames[macaddr] == '-') {
 					hostNames[macaddr] = leaseNames[i][j].hostname || '-';
 				}


### PR DESCRIPTION
`macaddr` can be undefined in some case.

<img width="1081" alt="Screen Shot 2020-11-23 at 9 45 29 PM" src="https://user-images.githubusercontent.com/743074/99969320-2ee27400-2d92-11eb-8332-137eb595cc71.png">
 