### PR TITLE
small Argon theme fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+runs-on: self-hosted
+
 on:
   push:
     tags:

--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/wrtbwmon.css
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/wrtbwmon.css
@@ -60,6 +60,9 @@ div > label + select {
 #thFirstSeen, #thLastSeen {
 	width: 15%;
 }
+#progressbar_panel > .tr {
+	background: none;
+}
 #progressbar_panel > .tr > .td:nth-child(1) {
 	width: 10%;
 }

--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/wrtbwmon.css
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/wrtbwmon.css
@@ -31,6 +31,9 @@ div > label + select {
 	min-width: unset;
 	width: auto;
 }
+#control_panel input[type="checkbox"]{
+	margin: 0
+}
 #control_panel + div {
 	display: flex;
 	margin-bottom: .5rem;


### PR DESCRIPTION
1. Argon add a margin to checkboxes, so they don't look aligned.
2. Argon use alternating colors for table rows.

fix them in styles.