### PR TITLE
Fix percentage calculation

### DIFF
--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
@@ -277,9 +277,10 @@ function parseDefaultSettings(file) {
 }
 
 function progressbar(query, v, m, useBits, useMultiple) {
+	// v = B/s, m = Mb/s
 	var pg = $(query),
-	    vn = v || 0,
-	    mn = formatBandWidth(m, useBits) || 100,
+	    vn = (v * 8) || 0,
+	    mn = (m * Math.pow(1000, 2)) || 100,
 	    fv = formatSpeed(v, useBits, useMultiple),
 	    pc = '%.2f'.format((100 / mn) * vn),
 	    wt = Math.floor(pc > 100 ? 100 : pc),

--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
@@ -135,10 +135,6 @@ function displayTable(tb, settings) {
 	progressbar('upstream', cachedData[1][1], settings.upstream, settings.useBits, settings.useMultiple);
 }
 
-function formatBandWidth(bdw, useBits) {
-	return bdw * Math.pow(1000, 2) / (useBits ? 1 : 8);
-}
-
 function formatSize(size, useBits, useMultiple) {
 	var res = String.format('%%%s.2m%s'.format(useMultiple, (useBits ? 'bit' : 'B')), useBits ? size * 8 : size);
 	return useMultiple == '1024' ? res.replace(/([KMGTPEZ])/, '$&i') : res;
@@ -280,7 +276,7 @@ function progressbar(query, v, m, useBits, useMultiple) {
 	// v = B/s, m = Mb/s
 	var pg = $(query),
 	    vn = (v * 8) || 0,
-	    mn = (m * Math.pow(1000, 2)) || 100,
+	    mn = (m || 100) * Math.pow(1000, 2),
 	    fv = formatSpeed(v, useBits, useMultiple),
 	    pc = '%.2f'.format((100 / mn) * vn),
 	    wt = Math.floor(pc > 100 ? 100 : pc),


### PR DESCRIPTION
```js
function progressbar(query, v, m, useBits, useMultiple) {
	var pg = $(query),
	    vn = v || 0,
	    mn = formatBandWidth(m, useBits) || 100,
	    fv = formatSpeed(v, useBits, useMultiple),
	    pc = '%.2f'.format((100 / mn) * vn),
	    ...
```
m is in Mbits/s, v is in bytes/s
m was getting converted to bytes/s when useBits was false, however, it wasn't when useBits was true, meaning all percentages were 1/8th what they should be