### PR TITLE
Fix IEC (1024) formatting (double i was being added)

### DIFF
--- a/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
+++ b/luci-app-wrtbwmon/htdocs/luci-static/resources/view/wrtbwmon/details.js
@@ -136,8 +136,8 @@ function displayTable(tb, settings) {
 }
 
 function formatSize(size, useBits, useMultiple) {
-	var res = String.format('%%%s.2m%s'.format(useMultiple, (useBits ? 'bit' : 'B')), useBits ? size * 8 : size);
-	return useMultiple == '1024' ? res.replace(/([KMGTPEZ])/, '$&i') : res;
+	// String.format automatically adds the i for KiB if the multiple is 1024
+	return String.format('%%%s.2m%s'.format(useMultiple, (useBits ? 'bit' : 'B')), useBits ? size * 8 : size);
 }
 
 function formatSpeed(speed, useBits, useMultiple) {


### PR DESCRIPTION
The javascript String.format function, automatically detects that IEC (1024) is being used as a multiple, and adds the "i" for Kibi, Mibi, etc. So the code removed would have added an extra "i" making it KiiB, MiiB, etc.
```js
> String.format('%1024.2mbit', 100000)
'97.66 Kibit'
> String.format('%1000.2mbit', 100000)
'100.00 Kbit'
```